### PR TITLE
Add qemu plugin for energy model data

### DIFF
--- a/inference/emulation_template/emulate-arm.sh
+++ b/inference/emulation_template/emulate-arm.sh
@@ -3,6 +3,8 @@ qemu-arm \
 	-g 3333 \
 	-one-insn-per-tb \
 	-plugin ./qemu-bin/contrib/plugins/libmemcnt.so \
+	-plugin ./qemu-bin/contrib/plugins/libpcchangecny.so \
+	-plugin ./qemu-bin/contrib/plugins/libmulcnt.so \
 	-plugin ./qemu-bin/tests/plugin/libinsn.so,inline=true \
 	-d plugin \
 	-D dump-$1.txt \

--- a/qemu.patch
+++ b/qemu.patch
@@ -1,84 +1,240 @@
 diff --git a/contrib/plugins/Makefile b/contrib/plugins/Makefile
-index 78d1b4885c..0b64d2c1e3 100644
+index 0b64d2c1e3..4ef4457c21 100644
 --- a/contrib/plugins/Makefile
 +++ b/contrib/plugins/Makefile
-@@ -18,8 +18,6 @@ NAMES += hotblocks
+@@ -18,6 +18,10 @@ NAMES += hotblocks
  NAMES += hotpages
  NAMES += howvec
  
--NAMES += memcnt
--
++NAMES += memcnt
++NAMES += pcchangecnt
++NAMES += mulcnt
++
  # The lockstep example communicates using unix sockets,
  # and can't be easily made to work on windows.
  ifneq ($(CONFIG_WIN32),y)
 diff --git a/contrib/plugins/memcnt.c b/contrib/plugins/memcnt.c
-deleted file mode 100644
-index 554bccf5d8..0000000000
---- a/contrib/plugins/memcnt.c
-+++ /dev/null
-@@ -1,64 +0,0 @@
--/*
-- * Copyright (C) 2024, Alessio Petruccelli <ale.petru97@gmail.com>
-- *
-- * Count mememory accesses
-- *
-- * License: GNU GPL, version 2 or later.
-- *   See the COPYING file in the top-level directory.
--*/
-- 
--#include <qemu-plugin.h>
--#include <stdint.h>
--#include <glib.h>
--
--QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
--
--typedef struct {
--    uint64_t read;
--    uint64_t write;
--} mem_count_t;
--
--static mem_count_t counter = {0};
--
--static void vcpu_mem(unsigned int cpu_index, qemu_plugin_meminfo_t meminfo,
--                     uint64_t vaddr, void *udata)
--{
--       if(qemu_plugin_mem_is_store(meminfo))
--       {
--           counter.write++;
--       }
--       else {
--            counter.read++;
--       }
--}
--
--static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb* tb)
--{
--    size_t n = qemu_plugin_tb_n_insns(tb);
--    
--    for(int i = 0; i < n; i++)
--    {
--        struct qemu_plugin_insn *insn = qemu_plugin_tb_get_insn(tb, i);
--        // Register the callbacks
--        qemu_plugin_register_vcpu_mem_cb(insn, vcpu_mem, QEMU_PLUGIN_CB_RW_REGS, QEMU_PLUGIN_MEM_RW, NULL);
--    }
--    
--}
--
--static void plugin_exit(qemu_plugin_id_t id, void* p)
--{
--    g_autoptr(GString) out = g_string_new(NULL);
--    
--    g_string_append_printf(out, "READ Accesses: %lu\nWRITE Accesses: %lu\n", counter.read, counter.write);
--    
--    qemu_plugin_outs(out->str);
--}
--
--
--QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id, const qemu_info_t* info, int argc, char** argv)
--{
--    /* Register translation block and exit callbacks */
--    qemu_plugin_register_vcpu_tb_trans_cb(id, vcpu_tb_trans);
--    qemu_plugin_register_atexit_cb(id, plugin_exit, NULL);
--    return 0;   
--}
-\ No newline at end of file
+new file mode 100644
+index 0000000000..e586b0609f
+--- /dev/null
++++ b/contrib/plugins/memcnt.c
+@@ -0,0 +1,89 @@
++/*
++ * Copyright (C) 2024, Alessio Petruccelli <ale.petru97@gmail.com>
++ *
++ * Count mememory accesses
++ *
++ * License: GNU GPL, version 2 or later.
++ *   See the COPYING file in the top-level directory.
++*/
++ 
++#include <qemu-plugin.h>
++#include <stdint.h>
++#include <glib.h>
++
++QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
++
++typedef struct {
++    uint64_t read;
++    uint64_t write;
++    uint64_t RAM_read;
++    uint64_t RAM_write;
++    uint64_t ROM_read;
++    uint64_t ROM_write;
++} mem_count_t;
++
++static mem_count_t counter = {0};
++
++static void vcpu_mem(unsigned int cpu_index, qemu_plugin_meminfo_t meminfo,
++                     uint64_t vaddr, void *udata)
++{
++    if(qemu_plugin_mem_is_store(meminfo))
++    {
++        counter.write++;
++        if(vaddr > 0x12000)
++        {
++            counter.ROM_write++;
++        }
++        else
++        {
++            counter.RAM_write++;
++        }
++    }
++    else
++    {
++        counter.read++;
++        if(vaddr > 0x12000)
++        {
++            counter.ROM_read++;
++        }
++        else
++        {
++            counter.RAM_read++;
++        }
++    }
++}
++
++static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb* tb)
++{
++    size_t n = qemu_plugin_tb_n_insns(tb);
++    
++    for(int i = 0; i < n; i++)
++    {
++        struct qemu_plugin_insn *insn = qemu_plugin_tb_get_insn(tb, i);
++        // Register the callbacks
++        qemu_plugin_register_vcpu_mem_cb(insn, vcpu_mem, QEMU_PLUGIN_CB_RW_REGS, QEMU_PLUGIN_MEM_RW, NULL);
++    }
++    
++}
++
++static void plugin_exit(qemu_plugin_id_t id, void* p)
++{
++    g_autoptr(GString) out = g_string_new(NULL);
++    
++    g_string_append_printf(out, "READ Accesses: %lu\nWRITE Accesses: %lu\nRAM READ: %lu\nROM READ: %lu\nRAM WRITE: %lu\nROM WRITE: %lu\n", 
++                    counter.read, counter.write,
++                    counter.RAM_read, counter.ROM_read,
++                    counter.RAM_write, counter.ROM_write);
++    
++    qemu_plugin_outs(out->str);
++}
++
++
++QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id, const qemu_info_t* info, int argc, char** argv)
++{
++    /* Register translation block and exit callbacks */
++    qemu_plugin_register_vcpu_tb_trans_cb(id, vcpu_tb_trans);
++    qemu_plugin_register_atexit_cb(id, plugin_exit, NULL);
++    return 0;   
++}
++
+diff --git a/contrib/plugins/mulcnt.c b/contrib/plugins/mulcnt.c
+new file mode 100644
+index 0000000000..5aaafde590
+--- /dev/null
++++ b/contrib/plugins/mulcnt.c
+@@ -0,0 +1,52 @@
++#include <qemu-plugin.h>
++#include <stdint.h>
++#include <glib.h>
++
++QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
++
++static uint64_t mul_count = 0;
++
++static void vcpu_mul(unsigned int cpu_index, void *udata) {
++    if (false) {
++        g_autoptr(GString) out = g_string_new(NULL);
++        g_string_append_printf(out, "\tMul!\n");
++        qemu_plugin_outs(out->str);
++    }
++    mul_count++;
++}
++
++static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb* tb) {
++    size_t n = qemu_plugin_tb_n_insns(tb);
++    
++    for (int i = 0; i < n; i++) {
++        struct qemu_plugin_insn *insn = qemu_plugin_tb_get_insn(tb, i);
++        uint64_t insn_size = qemu_plugin_insn_size(insn);
++        const uint8_t *bytes = qemu_plugin_insn_data(insn);
++        if ((insn_size == 2) && (bytes[1] == 0x43) && ((bytes[0] & 0xC0) == 0x40)) {
++            // Don't pass insn pointer to the callback function as *udata
++            //  cuz the pointer may later point to a different inst!!
++            // Just copy the used information in your inst!
++            qemu_plugin_register_vcpu_insn_exec_cb(insn, vcpu_mul,
++                        QEMU_PLUGIN_CB_R_REGS, insn);
++        }
++    }
++    
++}
++
++static void plugin_exit(qemu_plugin_id_t id, void* p) {
++    g_autoptr(GString) out = g_string_new(NULL);
++    
++    g_string_append_printf(out, "Multiplications: %lu\n", mul_count);
++    
++    qemu_plugin_outs(out->str);
++}
++
++QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id,
++                                        const qemu_info_t* info,
++                                        int argc,
++                                        char** argv) {
++    /* Register translation block and exit callbacks */
++    qemu_plugin_register_vcpu_tb_trans_cb(id, vcpu_tb_trans);
++    qemu_plugin_register_atexit_cb(id, plugin_exit, NULL);
++    return 0;   
++}
+diff --git a/contrib/plugins/pcchangecnt.c b/contrib/plugins/pcchangecnt.c
+new file mode 100644
+index 0000000000..b967888b38
+--- /dev/null
++++ b/contrib/plugins/pcchangecnt.c
+@@ -0,0 +1,66 @@
++#include <qemu-plugin.h>
++#include <stdint.h>
++#include <glib.h>
++
++QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
++
++static uint64_t expected_pc = 0;
++static uint64_t pc_change_count = 0;
++
++typedef struct {
++    uint64_t vaddr;
++    uint64_t size;
++} Instruction;
++
++static void vcpu_pc_change(unsigned int cpu_index, void *udata) {
++    Instruction* insn_info = (Instruction*) udata;
++    uint64_t vaddr = insn_info->vaddr;
++    uint64_t size = insn_info->size;
++    if (expected_pc != vaddr) {
++        if (false) {
++            g_autoptr(GString) out = g_string_new(NULL);
++            g_string_append_printf(out, "\tPC changed!\n");
++            qemu_plugin_outs(out->str);
++        }
++        pc_change_count++;
++    }
++    expected_pc = vaddr + size;
++}
++
++static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb* tb) {
++
++    size_t n = qemu_plugin_tb_n_insns(tb);
++    if (false) {
++        g_autoptr(GString) out = g_string_new(NULL);
++        g_string_append_printf(out, "Register tb @%p with %lu insts\n",
++                    tb, n);
++        qemu_plugin_outs(out->str);
++    }
++    for (int i = 0; i < n; i++) {
++        struct qemu_plugin_insn *insn = qemu_plugin_tb_get_insn(tb, i);
++        Instruction* insn_info = g_new0(Instruction, 1);
++        insn_info->vaddr = qemu_plugin_insn_vaddr(insn);
++        insn_info->size = qemu_plugin_insn_size(insn);
++        qemu_plugin_register_vcpu_insn_exec_cb(insn, vcpu_pc_change,
++                    QEMU_PLUGIN_CB_R_REGS, insn_info);
++    }
++    
++}
++
++static void plugin_exit(qemu_plugin_id_t id, void* p) {
++    g_autoptr(GString) out = g_string_new(NULL);
++    
++    g_string_append_printf(out, "Times of PC change: %lu\n", pc_change_count);
++    
++    qemu_plugin_outs(out->str);
++}
++
++QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id,
++                                        const qemu_info_t* info,
++                                        int argc,
++                                        char** argv) {
++    /* Register translation block and exit callbacks */
++    qemu_plugin_register_vcpu_tb_trans_cb(id, vcpu_tb_trans);
++    qemu_plugin_register_atexit_cb(id, plugin_exit, NULL);
++    return 0;   
++}


### PR DESCRIPTION
For the energy model see Nikov et al: Accurate Energy Modelling on the Cortex-M0 Processor for Profiling and Static Analysis

This change to the qemu patch includes updates to qemu plugin memcnt.c (differentiating RAM/ROM access), and additionally two new plugins mulcnt.c and pcchangecnt.c. 